### PR TITLE
feat: add ScriptContext and AppContext extensions for .NET 10 file-based apps

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -99,6 +99,9 @@ dotnet_style_allow_statement_immediately_after_block_experimental = false:warnin
 
 #### C# Coding Conventions ####
 
+# ConfigureAwait - Not needed for console apps and libraries that might be used in console apps
+dotnet_diagnostic.CA2007.severity = none
+
 # var preferences
 csharp_style_var_elsewhere = false:warning
 csharp_style_var_for_built_in_types = false:warning
@@ -301,34 +304,25 @@ dotnet_diagnostic.globalusingsanalyzer0003.severity = warning
 [Scripts/*.cs]
 # CA1303: Do not pass literals as localized parameters - Not needed for build scripts
 dotnet_diagnostic.CA1303.severity = none
-# CA2007: Consider calling ConfigureAwait on the awaited task - Not needed for console apps
-dotnet_diagnostic.CA2007.severity = none
 # CA1031: Do not catch general exception types - Acceptable for build scripts
 dotnet_diagnostic.CA1031.severity = none
 # CA2000: Dispose objects before losing scope - Process is disposed properly
 dotnet_diagnostic.CA2000.severity = none
 
 #### Test Scripts Analyzer Settings ####
-[Tests/**/*.cs]
+[Tests/**.cs]
 # CA1303: Do not pass literals as localized parameters - Not needed for tests
 dotnet_diagnostic.CA1303.severity = none
-# CA2007: Consider calling ConfigureAwait on the awaited task - Not needed for test scripts
-dotnet_diagnostic.CA2007.severity = none
 # CA1031: Do not catch general exception types - Acceptable for test scripts
 dotnet_diagnostic.CA1031.severity = none
 
-[Tests/*.cs]
-# CA1303: Do not pass literals as localized parameters - Not needed for tests
+#### Samples Analyzer Settings ####
+[Samples/**.cs]
+# CA1303: Do not pass literals as localized parameters - Not needed for sample code
 dotnet_diagnostic.CA1303.severity = none
-# CA2007: Consider calling ConfigureAwait on the awaited task - Not needed for test scripts
-dotnet_diagnostic.CA2007.severity = none
-# CA1031: Do not catch general exception types - Acceptable for test scripts
-dotnet_diagnostic.CA1031.severity = none
 
 #### Library Analyzer Settings ####
-[Source/**/*.cs]
-# CA2007: ConfigureAwait - Not needed for a library that might be used in console apps
-dotnet_diagnostic.CA2007.severity = none
+[Source/**.cs]
 # CA1031: Do not catch general exception types - We want graceful error handling
 dotnet_diagnostic.CA1031.severity = none
 # CA1062: Validate arguments of public methods - Extension methods often don't need null checks

--- a/Documentation/Developer/HowToGuides/HowToUseAppContextExtensions.md
+++ b/Documentation/Developer/HowToGuides/HowToUseAppContextExtensions.md
@@ -1,0 +1,159 @@
+# How to Use AppContext Extensions for .NET 10 File-Based Apps
+
+## Overview
+
+TimeWarp.Amuru provides extension methods for `AppContext` using C# 14's new extension syntax, giving you clean access to .NET 10's file-based app metadata without magic strings.
+
+## Prerequisites
+
+- .NET 10 SDK
+- TimeWarp.Amuru package
+- C# script file (not a project)
+
+## Basic Usage
+
+```csharp
+#!/usr/bin/dotnet --
+#:package TimeWarp.Amuru
+#:property LangVersion=preview
+#:property EnablePreviewFeatures=true
+
+using TimeWarp.Amuru;
+
+// Access script metadata using extension methods
+string? scriptPath = AppContext.EntryPointFilePath();
+string? scriptDir = AppContext.EntryPointFileDirectoryPath();
+
+Console.WriteLine($"Script: {scriptPath}");
+Console.WriteLine($"Directory: {scriptDir}");
+```
+
+## What These Extensions Provide
+
+### EntryPointFilePath()
+Returns the full path to the currently executing script file.
+
+**Example Output**: `/home/user/scripts/MyScript.cs`
+
+### EntryPointFileDirectoryPath()
+Returns the directory containing the currently executing script.
+
+**Example Output**: `/home/user/scripts`
+
+## Common Use Cases
+
+### Locating Related Files
+
+```csharp
+string? scriptDir = AppContext.EntryPointFileDirectoryPath();
+if (scriptDir != null)
+{
+    string configFile = Path.Combine(scriptDir, "config.json");
+    if (File.Exists(configFile))
+    {
+        var config = File.ReadAllText(configFile);
+        // Process configuration
+    }
+}
+```
+
+### Script Self-Identification
+
+```csharp
+string? scriptPath = AppContext.EntryPointFilePath();
+if (scriptPath != null)
+{
+    Console.WriteLine($"Running: {Path.GetFileName(scriptPath)}");
+    Console.WriteLine($"Extension: {Path.GetExtension(scriptPath)}");
+    Console.WriteLine($"Last modified: {File.GetLastWriteTime(scriptPath)}");
+}
+```
+
+### Finding Sibling Scripts
+
+```csharp
+string? scriptDir = AppContext.EntryPointFileDirectoryPath();
+if (scriptDir != null)
+{
+    var otherScripts = Directory.GetFiles(scriptDir, "*.cs")
+        .Where(f => f != AppContext.EntryPointFilePath())
+        .ToList();
+    
+    Console.WriteLine("Other scripts in directory:");
+    foreach (var script in otherScripts)
+    {
+        Console.WriteLine($"  - {Path.GetFileName(script)}");
+    }
+}
+```
+
+## How It Works
+
+These extension methods wrap the .NET 10 AppContext data:
+- `AppContext.GetData("EntryPointFilePath")` → `AppContext.EntryPointFilePath()`
+- `AppContext.GetData("EntryPointFileDirectoryPath")` → `AppContext.EntryPointFileDirectoryPath()`
+
+The C# 14 extension syntax allows us to add these methods to the static `AppContext` class, providing a cleaner API.
+
+## When to Use
+
+**Use AppContext Extensions when:**
+- You need to know where your script is located
+- You want to access files relative to the script
+- You're building self-aware scripts
+- You need script metadata for logging or debugging
+
+**Use ScriptContext instead when:**
+- You need to change the working directory
+- You want automatic directory restoration
+- You need cleanup callbacks
+- You're managing directory state
+
+## Null Handling
+
+These methods return `null` when:
+- Not running as a file-based app (e.g., compiled project)
+- Running in environments that don't set this data
+
+Always check for null:
+
+```csharp
+string? scriptPath = AppContext.EntryPointFilePath();
+if (scriptPath == null)
+{
+    Console.WriteLine("Not running as a file-based app");
+    return;
+}
+// Safe to use scriptPath
+```
+
+## Comparison with Traditional Approaches
+
+### Before (Magic Strings)
+```csharp
+string? scriptPath = AppContext.GetData("EntryPointFilePath") as string;
+string? scriptDir = AppContext.GetData("EntryPointFileDirectoryPath") as string;
+```
+
+### After (Extension Methods)
+```csharp
+string? scriptPath = AppContext.EntryPointFilePath();
+string? scriptDir = AppContext.EntryPointFileDirectoryPath();
+```
+
+## Requirements
+
+The script must:
+1. Use the shebang: `#!/usr/bin/dotnet --`
+2. Be executable: `chmod +x script.cs`
+3. Include preview features for C# 14 extensions:
+   ```csharp
+   #:property LangVersion=preview
+   #:property EnablePreviewFeatures=true
+   ```
+
+## See Also
+
+- [How to Use ScriptContext](HowToUseScriptContext.md)
+- [.NET 10 File-Based Apps Documentation](https://docs.microsoft.com/dotnet/core/file-based-apps)
+- [C# 14 Extension Everything](https://github.com/dotnet/csharplang/blob/main/proposals/extensions.md)

--- a/Documentation/Developer/HowToGuides/HowToUseScriptContext.md
+++ b/Documentation/Developer/HowToGuides/HowToUseScriptContext.md
@@ -1,0 +1,141 @@
+# How to Use ScriptContext for .NET 10 File-Based Apps
+
+## Overview
+
+`ScriptContext` provides automatic working directory management for .NET 10 file-based apps (single-file C# scripts). It ensures your script's working directory is properly set and restored, even when using `Environment.Exit()`.
+
+## Prerequisites
+
+- .NET 10 SDK
+- TimeWarp.Amuru package
+
+## Basic Usage
+
+### Working in Script's Directory
+
+```csharp
+#!/usr/bin/dotnet --
+#:package TimeWarp.Amuru
+
+using TimeWarp.Amuru;
+
+// Automatically change to script's directory and restore on disposal
+using (var context = ScriptContext.FromEntryPoint())
+{
+    Console.WriteLine($"Script: {context.ScriptFilePath}");
+    Console.WriteLine($"Working in: {context.ScriptDirectory}");
+    
+    // Your script operations here
+    // Working directory is the script's directory
+    var files = await Shell.Run("ls").GetLinesAsync();
+}
+// Original directory automatically restored
+```
+
+## Advanced Scenarios
+
+### Navigate to a Relative Path
+
+When your script needs to work from a different directory relative to the script's location:
+
+```csharp
+using (var context = ScriptContext.FromRelativePath(".."))
+{
+    // Now working from parent directory
+    await Shell.Run("dotnet", "build").ExecuteAsync();
+}
+// Original directory restored
+```
+
+### Custom Cleanup Actions
+
+Add cleanup code that runs even if the script exits abruptly:
+
+```csharp
+using (var context = ScriptContext.FromEntryPoint(
+    changeToScriptDirectory: true,
+    onExit: () => 
+    {
+        Console.WriteLine("Cleaning up temporary files...");
+        File.Delete("temp.txt");
+    }))
+{
+    // Your script work
+    if (error)
+        Environment.Exit(1); // Cleanup still runs!
+}
+```
+
+### Controlling Directory Change
+
+Sometimes you want the context without changing directories:
+
+```csharp
+using (var context = ScriptContext.FromEntryPoint(changeToScriptDirectory: false))
+{
+    // Access script path without changing directory
+    Console.WriteLine($"Script at: {context.ScriptFilePath}");
+    Console.WriteLine($"Still in: {Directory.GetCurrentDirectory()}");
+}
+```
+
+## How It Works
+
+1. **On Creation**: Captures current directory, optionally changes to script or relative directory
+2. **During Use**: Provides access to script metadata through properties
+3. **On Disposal**: Restores original directory and runs cleanup callbacks
+4. **On Process Exit**: Intercepts `Environment.Exit()` and unhandled exceptions to ensure cleanup
+
+## Best Practices
+
+1. **Always use `using` blocks** to ensure proper disposal
+2. **Place ScriptContext at the start** of your script's Main method
+3. **Use relative paths** after changing directory
+4. **Add cleanup callbacks** for critical resources
+5. **Prefer ScriptContext over manual directory management**
+
+## Common Patterns
+
+### Build Script Pattern
+```csharp
+using (var context = ScriptContext.FromRelativePath(".."))
+{
+    await DotNet.Build()
+        .WithProject("./Source/Project.csproj")
+        .ExecuteAsync();
+}
+```
+
+### Test Runner Pattern
+```csharp
+using (var context = ScriptContext.FromEntryPoint())
+{
+    var testFiles = await Shell.Run("find")
+        .WithArguments(".", "-name", "*.Test.cs")
+        .GetLinesAsync();
+        
+    foreach (var test in testFiles)
+    {
+        await Shell.Run(test).ExecuteAsync();
+    }
+}
+```
+
+## Troubleshooting
+
+### Script Path is Null
+- Ensure you're running as a .NET 10 file-based app (not `dotnet run` on a project)
+- Use the shebang: `#!/usr/bin/dotnet --`
+
+### Directory Not Restored
+- Check that you're using a `using` block or calling `Dispose()`
+- The directory is restored even with `Environment.Exit()`, but not on process kill
+
+### Cleanup Not Running
+- Cleanup runs on normal disposal, `Environment.Exit()`, and unhandled exceptions
+- It does NOT run on `kill -9` or Windows Task Manager force-quit
+
+## See Also
+
+- [How to Use AppContext Extensions](HowToUseAppContextExtensions.md)
+- [.NET 10 File-Based Apps Documentation](https://docs.microsoft.com/dotnet/core/file-based-apps)

--- a/Documentation/Overview.md
+++ b/Documentation/Overview.md
@@ -1,0 +1,28 @@
+# TimeWarp.Amuru Documentation
+
+Welcome to the TimeWarp.Amuru documentation. This library provides a fluent API for elegant command-line execution in C#.
+
+## Documentation Structure
+
+### [Developer Documentation](Developer/)
+Technical documentation for developers using TimeWarp.Amuru in their projects.
+
+- **[How-To Guides](Developer/HowToGuides/)** - Step-by-step instructions for specific tasks
+  - [How to Use ScriptContext](Developer/HowToGuides/HowToUseScriptContext.md)
+  - [How to Use AppContext Extensions](Developer/HowToGuides/HowToUseAppContextExtensions.md)
+
+### [Samples](../Samples/)
+Working code examples demonstrating library features:
+- `AppContextExtensionsExample.cs` - Using AppContext extensions in scripts
+- `ScriptContextExample.cs` - Directory management with ScriptContext
+
+## Quick Links
+
+- [GitHub Repository](https://github.com/TimeWarpEngineering/timewarp-amuru)
+- [NuGet Package](https://www.nuget.org/packages/TimeWarp.Amuru/)
+- [Release Notes](https://github.com/TimeWarpEngineering/timewarp-amuru/releases)
+
+## Getting Help
+
+- [File an Issue](https://github.com/TimeWarpEngineering/timewarp-amuru/issues)
+- [Discord Community](https://discord.gg/7F4bS2T)

--- a/Kanban/InProgress/008_Add-ScriptContext-And-AppContext-Extensions.md
+++ b/Kanban/InProgress/008_Add-ScriptContext-And-AppContext-Extensions.md
@@ -1,0 +1,58 @@
+# Task 008: Add ScriptContext and AppContext Extensions
+
+## Issue Reference
+GitHub Issue: #6
+
+## Status
+🚧 InProgress
+
+## Description
+Add .NET 10 file-based app helper extensions and ScriptContext to TimeWarp.Amuru to simplify script development.
+
+## Background
+.NET 10 introduces native support for file-based apps with new AppContext data:
+- `AppContext.GetData("EntryPointFilePath")` - Path to the script file
+- `AppContext.GetData("EntryPointFileDirectoryPath")` - Path to the script directory
+
+Every file-based app needs:
+1. Access to script location without magic strings
+2. Pattern to change working directory and restore it on completion/failure
+
+## Requirements
+- [ ] Implement AppContextExtensions class with EntryPointFilePath and EntryPointFileDirectoryPath methods
+- [ ] Implement ScriptContext class with IDisposable pattern for directory management
+- [ ] Add FromEntryPoint method for working in script directory
+- [ ] Add FromRoot method for working from repository root
+- [ ] Update existing scripts to use ScriptContext
+- [ ] Add tests for new functionality
+- [ ] Bump version to 1.0.0-beta.2
+
+## Implementation Details
+
+### AppContextExtensions
+```csharp
+public static class AppContextExtensions
+{
+    public static string? EntryPointFilePath(this AppContext _) 
+        => AppContext.GetData("EntryPointFilePath") as string;
+        
+    public static string? EntryPointFileDirectoryPath(this AppContext _) 
+        => AppContext.GetData("EntryPointFileDirectoryPath") as string;
+}
+```
+
+### ScriptContext
+- Sealed class implementing IDisposable
+- Stores original directory and restores on disposal
+- FromEntryPoint method for script directory
+- FromRoot method for repository root navigation
+- Properties: ScriptDirectory, ScriptFilePath
+
+## Notes
+- Follows disposable pattern for automatic cleanup
+- No magic strings required
+- Clean, readable scripts
+- Reusable across all file-based apps
+
+## References
+- [.NET 10 Preview 6 SDK File-Based Apps](https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview6/sdk.md#file-based-apps)

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Check out the latest NuGet package: [TimeWarp.Cli](https://www.nuget.org/package
 - **C# Script Support**: Seamless execution of C# scripts with proper argument handling
 - **Command Builders**: Fluent builders for complex commands (DotNet, Fzf, Ghq, Gwq)
 - **Interactive Commands**: Support for interactive tools like FZF with `GetStringInteractiveAsync()` and `ExecuteInteractiveAsync()`
+- **.NET 10 Script Support**: AppContext extensions and ScriptContext for file-based apps
 
 ## Error Handling
 
@@ -212,6 +213,16 @@ For commands like `fzf` that are normally interactive, you can either:
 - `CliConfiguration.Reset()` - Clear all custom paths
 - `CliConfiguration.HasCustomPath(command)` - Check if command has custom path
 - `CliConfiguration.AllCommandPaths` - Get all configured paths
+
+## .NET 10 File-Based App Support
+
+TimeWarp.Amuru provides specialized support for .NET 10's new file-based apps (single-file C# scripts) with AppContext extensions and ScriptContext for directory management.
+
+- **AppContext Extensions** - Clean access to script metadata without magic strings
+- **ScriptContext** - Automatic working directory management with cleanup guarantees
+- **ProcessExit Handling** - Cleanup runs even with `Environment.Exit()`
+
+📖 **[See the documentation](Documentation/Developer/HowToGuides/)** for detailed usage guides and examples.
 
 ## Architecture
 

--- a/Samples/AppContextExtensionsExample.cs
+++ b/Samples/AppContextExtensionsExample.cs
@@ -1,0 +1,54 @@
+#!/usr/bin/dotnet --
+#:project ../Source/TimeWarp.Amuru/TimeWarp.Amuru.csproj
+#:property LangVersion=preview
+#:property EnablePreviewFeatures=true
+
+// Example demonstrating AppContext extensions for .NET 10 file-based apps
+
+using TimeWarp.Amuru;
+
+Console.WriteLine("=== AppContext Extensions Example ===\n");
+
+// These extension methods provide access to .NET 10's file-based app context data
+// without using magic strings
+
+Console.WriteLine("File-based app context information:");
+Console.WriteLine($"Entry Point File Path: {AppContext.EntryPointFilePath()}");
+Console.WriteLine($"Entry Point Directory: {AppContext.EntryPointFileDirectoryPath()}");
+
+// These are equivalent to the magic string approach:
+// AppContext.GetData("EntryPointFilePath")
+// AppContext.GetData("EntryPointFileDirectoryPath")
+
+Console.WriteLine("\nUsing the information:");
+
+string? scriptPath = AppContext.EntryPointFilePath();
+if (scriptPath != null)
+{
+  Console.WriteLine($"Script name: {Path.GetFileName(scriptPath)}");
+  Console.WriteLine($"Script extension: {Path.GetExtension(scriptPath)}");
+}
+
+string? scriptDir = AppContext.EntryPointFileDirectoryPath();
+if (scriptDir != null)
+{
+  Console.WriteLine($"Parent directory: {Path.GetFileName(scriptDir)}");
+  
+  // List other scripts in the same directory
+  string[] otherScripts = await Shell.Run("find")
+    .WithArguments(scriptDir, "-maxdepth", "1", "-name", "*.cs", "-type", "f")
+    .GetLinesAsync();
+  
+  Console.WriteLine($"\nOther scripts in {Path.GetFileName(scriptDir)}:");
+  foreach (string script in otherScripts)
+  {
+    Console.WriteLine($"  - {Path.GetFileName(script)}");
+  }
+}
+
+Console.WriteLine("\n✅ AppContext extensions demonstration complete!");
+Console.WriteLine("Testing CA1303 suppression with a literal string!");
+
+// Test CA2007 suppression - await without ConfigureAwait
+string testOutput = await Shell.Run("echo").WithArguments("CA2007 test").GetStringAsync();
+Console.WriteLine($"CA2007 test result: {testOutput.Trim()}");

--- a/Samples/ScriptContextExample.cs
+++ b/Samples/ScriptContextExample.cs
@@ -1,0 +1,61 @@
+#!/usr/bin/dotnet --
+#:project ../Source/TimeWarp.Amuru/TimeWarp.Amuru.csproj
+#:property LangVersion=preview
+#:property EnablePreviewFeatures=true
+
+// Example demonstrating ScriptContext usage
+
+using TimeWarp.Amuru;
+
+Console.WriteLine("=== ScriptContext Example ===\n");
+
+// Example 1: Basic usage - work in script's directory
+Console.WriteLine("Example 1: Working in script directory");
+using (var context = ScriptContext.FromEntryPoint())
+{
+  Console.WriteLine($"Script: {context.ScriptFilePath}");
+  Console.WriteLine($"Script Dir: {context.ScriptDirectory}");
+  Console.WriteLine($"Working Dir: {Directory.GetCurrentDirectory()}");
+  
+  // Do work in script directory
+  string[] localFiles = await Shell.Run("ls").GetLinesAsync();
+  Console.WriteLine($"Files in script dir: {localFiles.Length}");
+}
+
+Console.WriteLine($"After disposal: {Directory.GetCurrentDirectory()}\n");
+
+// Example 2: Navigate to parent directory
+Console.WriteLine("Example 2: Working from parent directory");
+using (var context = ScriptContext.FromRelativePath("..", changeToTargetDirectory: true))
+{
+  Console.WriteLine($"Working Dir: {Directory.GetCurrentDirectory()}");
+  
+  // List parent directory items
+  string[] parentItems = await Shell.Run("ls").GetLinesAsync();
+  Console.WriteLine("Parent directory items:");
+  foreach (string item in parentItems.Take(5))
+  {
+    Console.WriteLine($"  - {item}");
+  }
+}
+
+Console.WriteLine($"After disposal: {Directory.GetCurrentDirectory()}\n");
+
+// Example 3: With cleanup callback
+Console.WriteLine("Example 3: With cleanup callback");
+bool cleanupExecuted = false;
+using (var context = ScriptContext.FromEntryPoint(
+  changeToScriptDirectory: true,
+  onExit: () => 
+  {
+    cleanupExecuted = true;
+    Console.WriteLine("  Cleanup callback executed!");
+  }))
+{
+  Console.WriteLine($"Working in: {Directory.GetCurrentDirectory()}");
+  Console.WriteLine("  Doing some work...");
+}
+
+Console.WriteLine($"Cleanup executed: {cleanupExecuted}");
+
+Console.WriteLine("\n✅ All examples completed!");

--- a/Scripts/DisableBranchProtection.cs
+++ b/Scripts/DisableBranchProtection.cs
@@ -1,19 +1,17 @@
-#!/usr/bin/dotnet run
+#!/usr/bin/dotnet --
+#:project ../Source/TimeWarp.Amuru/TimeWarp.Amuru.csproj
+#:property LangVersion=preview
+#:property EnablePreviewFeatures=true
+
 // DisableBranchProtection.cs - Disable branch protection on the default branch
 
-// Get script directory using CallerFilePath
-static string GetScriptDirectory([CallerFilePath] string scriptPath = "")
-{
-  return Path.GetDirectoryName(scriptPath) ?? "";
-}
+using TimeWarp.Amuru;
 
-// Push current directory, change to script directory for relative paths
-string originalDirectory = Directory.GetCurrentDirectory();
-string scriptDir = GetScriptDirectory();
-Directory.SetCurrentDirectory(scriptDir);
+// Use ScriptContext to manage directory changes
+using var context = ScriptContext.FromEntryPoint();
 
 Console.WriteLine("🔓 Disabling branch protection on master branch...");
-Console.WriteLine($"Script directory: {scriptDir}");
+Console.WriteLine($"Script directory: {context.ScriptDirectory}");
 Console.WriteLine($"Working from: {Directory.GetCurrentDirectory()}");
 
 try
@@ -65,8 +63,5 @@ catch (Exception ex)
   Console.WriteLine($"❌ An error occurred: {ex.Message}");
   Environment.Exit(1);
 }
-finally
-{
-  // Pop - restore original working directory
-  Directory.SetCurrentDirectory(originalDirectory);
-}
+
+// ScriptContext automatically restores directory on disposal

--- a/Scripts/EnableBranchProtection.cs
+++ b/Scripts/EnableBranchProtection.cs
@@ -1,20 +1,17 @@
-#!/usr/bin/dotnet run
+#!/usr/bin/dotnet --
+#:project ../Source/TimeWarp.Amuru/TimeWarp.Amuru.csproj
+#:property LangVersion=preview
+#:property EnablePreviewFeatures=true
+
 // EnableBranchProtection.cs - Enable branch protection on the default branch
 
+using TimeWarp.Amuru;
 
-// Get script directory using CallerFilePath
-static string GetScriptDirectory([CallerFilePath] string scriptPath = "")
-{
-  return Path.GetDirectoryName(scriptPath) ?? "";
-}
-
-// Push current directory, change to script directory for relative paths
-string originalDirectory = Directory.GetCurrentDirectory();
-string scriptDir = GetScriptDirectory();
-Directory.SetCurrentDirectory(scriptDir);
+// Use ScriptContext to manage directory changes
+using var context = ScriptContext.FromEntryPoint();
 
 Console.WriteLine("🔒 Enabling branch protection on master branch...");
-Console.WriteLine($"Script directory: {scriptDir}");
+Console.WriteLine($"Script directory: {context.ScriptDirectory}");
 Console.WriteLine($"Working from: {Directory.GetCurrentDirectory()}");
 
 try
@@ -99,8 +96,5 @@ catch (Exception ex)
   Console.WriteLine($"❌ An error occurred: {ex.Message}");
   Environment.Exit(1);
 }
-finally
-{
-  // Pop - restore original working directory
-  Directory.SetCurrentDirectory(originalDirectory);
-}
+
+// ScriptContext automatically restores directory on disposal

--- a/Source/TimeWarp.Amuru/AppContextExtensions.cs
+++ b/Source/TimeWarp.Amuru/AppContextExtensions.cs
@@ -1,0 +1,15 @@
+namespace TimeWarp.Amuru;
+
+#pragma warning disable CA1034 // Nested types should not be visible
+public static class AppContextExtensions
+{
+  extension(AppContext)
+  {
+    public static string? EntryPointFilePath() 
+      => AppContext.GetData("EntryPointFilePath") as string;
+    
+    public static string? EntryPointFileDirectoryPath() 
+      => AppContext.GetData("EntryPointFileDirectoryPath") as string;
+  }
+}
+#pragma warning restore CA1034

--- a/Source/TimeWarp.Amuru/ScriptContext.cs
+++ b/Source/TimeWarp.Amuru/ScriptContext.cs
@@ -1,0 +1,91 @@
+namespace TimeWarp.Amuru;
+
+public sealed class ScriptContext : IDisposable
+{
+  private readonly string OriginalDirectory;
+  private readonly Action? OnExit;
+  private static ScriptContext? Current;
+
+  public string ScriptDirectory { get; }
+  public string ScriptFilePath { get; }
+
+  private ScriptContext(string scriptFilePath, string scriptDirectory, Action? onExit = null)
+  {
+    OriginalDirectory = Directory.GetCurrentDirectory();
+    ScriptFilePath = scriptFilePath;
+    ScriptDirectory = scriptDirectory;
+    OnExit = onExit;
+    
+    // Register for process exit events to ensure cleanup
+    if (Current == null)
+    {
+      Current = this;
+      AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+      AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+    }
+  }
+
+  public static ScriptContext FromEntryPoint(bool changeToScriptDirectory = true, Action? onExit = null)
+  {
+    string? scriptPath = AppContext.GetData("EntryPointFilePath") as string 
+      ?? throw new InvalidOperationException("Not running as file-based app");
+    string? scriptDir = AppContext.GetData("EntryPointFileDirectoryPath") as string 
+      ?? throw new InvalidOperationException("Unable to determine script directory");
+
+    ScriptContext context = new(scriptPath, scriptDir, onExit);
+
+    if (changeToScriptDirectory)
+      Directory.SetCurrentDirectory(scriptDir);
+
+    return context;
+  }
+
+  public static ScriptContext FromRelativePath(string relativePath = "..", bool changeToTargetDirectory = true, Action? onExit = null)
+  {
+    string? scriptDir = AppContext.GetData("EntryPointFileDirectoryPath") as string 
+      ?? throw new InvalidOperationException("Unable to determine script directory");
+    string scriptPath = AppContext.GetData("EntryPointFilePath") as string ?? "";
+
+    string targetDir = Path.GetFullPath(Path.Combine(scriptDir, relativePath));
+    ScriptContext context = new(scriptPath, scriptDir, onExit);
+
+    if (changeToTargetDirectory)
+      Directory.SetCurrentDirectory(targetDir);
+
+    return context;
+  }
+
+  private static void OnProcessExit(object? sender, EventArgs e)
+  {
+    Current?.Cleanup();
+  }
+
+  private static void OnUnhandledException(object? sender, UnhandledExceptionEventArgs e)
+  {
+    Current?.Cleanup();
+  }
+
+  private void Cleanup()
+  {
+    try
+    {
+      Directory.SetCurrentDirectory(OriginalDirectory);
+      OnExit?.Invoke();
+    }
+    catch
+    {
+      // Best effort cleanup - don't throw in cleanup handlers
+    }
+  }
+
+  public void Dispose()
+  {
+    if (Current == this)
+    {
+      Cleanup();
+      AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
+      AppDomain.CurrentDomain.UnhandledException -= OnUnhandledException;
+      Current = null;
+    }
+  }
+}

--- a/Source/TimeWarp.Amuru/TimeWarp.Amuru.csproj
+++ b/Source/TimeWarp.Amuru/TimeWarp.Amuru.csproj
@@ -2,12 +2,14 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageOutputPath>../../LocalNuGetFeed</PackageOutputPath>
     <PackageId>TimeWarp.Amuru</PackageId>
-    <Version>1.0.0-beta.1</Version>
+    <Version>1.0.0-beta.2</Version>
     <Authors>Steven T. Cramer</Authors>
     <Description>Fluent API for elegant C# scripting with pipeline support</Description>
     <PackageTags>cli;scripting;fluent;shell;pipeline;amuru</PackageTags>

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -4,7 +4,12 @@
 
   <PropertyGroup>
     <!-- Disable specific analyzer warnings for test projects -->
-    <NoWarn>$(NoWarn);CA1812;CS1998</NoWarn>
+    <NoWarn>$(NoWarn);CA1812;CS1998;CS8652;CA2252</NoWarn>
+    <!-- CS8652: Feature 'extensions' is in Preview -->
+    <!-- CA2252: Using preview features -->
+    <!-- Enable preview features for tests -->
+    <LangVersion>preview</LangVersion>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Integration/ScriptSupport/AppContextExtensions.cs
+++ b/Tests/Integration/ScriptSupport/AppContextExtensions.cs
@@ -1,0 +1,63 @@
+#!/usr/bin/dotnet run
+
+await RunTests<AppContextExtensionsTests>();
+
+internal sealed class AppContextExtensionsTests
+{
+  public static Task TestEntryPointFilePathReturnsCorrectPath()
+  {
+    string? filePath = AppContext.EntryPointFilePath();
+    
+    AssertTrue(
+      filePath != null,
+      "EntryPointFilePath should not be null for file-based apps"
+    );
+    
+    AssertTrue(
+      filePath!.EndsWith(".cs", StringComparison.Ordinal),
+      $"EntryPointFilePath should end with .cs, got: {filePath}"
+    );
+    
+    AssertTrue(
+      File.Exists(filePath),
+      $"EntryPointFilePath should point to an existing file: {filePath}"
+    );
+    
+    return Task.CompletedTask;
+  }
+  
+  public static Task TestEntryPointFileDirectoryPathReturnsCorrectPath()
+  {
+    string? dirPath = AppContext.EntryPointFileDirectoryPath();
+    
+    AssertTrue(
+      dirPath != null,
+      "EntryPointFileDirectoryPath should not be null for file-based apps"
+    );
+    
+    AssertTrue(
+      Directory.Exists(dirPath),
+      $"EntryPointFileDirectoryPath should point to an existing directory: {dirPath}"
+    );
+    
+    return Task.CompletedTask;
+  }
+  
+  public static Task TestBothExtensionsReturnConsistentPaths()
+  {
+    string? filePath = AppContext.EntryPointFilePath();
+    string? dirPath = AppContext.EntryPointFileDirectoryPath();
+    
+    AssertTrue(filePath != null, "FilePath should not be null");
+    AssertTrue(dirPath != null, "DirPath should not be null");
+    
+    string? fileDir = Path.GetDirectoryName(filePath);
+    
+    AssertTrue(
+      fileDir == dirPath,
+      $"Directory from EntryPointFilePath should match EntryPointFileDirectoryPath: {fileDir} != {dirPath}"
+    );
+    
+    return Task.CompletedTask;
+  }
+}

--- a/Tests/Integration/ScriptSupport/ScriptContext.cs
+++ b/Tests/Integration/ScriptSupport/ScriptContext.cs
@@ -1,0 +1,130 @@
+#!/usr/bin/dotnet run
+
+await RunTests<ScriptContextTests>();
+
+internal sealed class ScriptContextTests
+{
+  public static Task TestFromEntryPointChangesDirectory()
+  {
+    string originalDir = Directory.GetCurrentDirectory();
+    string? expectedDir = AppContext.EntryPointFileDirectoryPath();
+    
+    AssertTrue(expectedDir != null, "EntryPointFileDirectoryPath should not be null");
+    
+    using (var context = ScriptContext.FromEntryPoint())
+    {
+      string currentDir = Directory.GetCurrentDirectory();
+      
+      AssertTrue(
+        expectedDir == currentDir,
+        $"ScriptContext should change to script directory: {expectedDir} != {currentDir}"
+      );
+      
+      AssertTrue(
+        context.ScriptDirectory == currentDir,
+        $"ScriptDirectory property should match current directory: {context.ScriptDirectory} != {currentDir}"
+      );
+    }
+    
+    // After disposal, directory should be restored
+    string restoredDir = Directory.GetCurrentDirectory();
+    AssertTrue(
+      originalDir == restoredDir,
+      $"Directory should be restored after disposal: {originalDir} != {restoredDir}"
+    );
+    
+    return Task.CompletedTask;
+  }
+  
+  public static Task TestFromEntryPointWithoutDirectoryChange()
+  {
+    string originalDir = Directory.GetCurrentDirectory();
+    
+    using (var context = ScriptContext.FromEntryPoint(changeToScriptDirectory: false))
+    {
+      string currentDir = Directory.GetCurrentDirectory();
+      
+      AssertTrue(
+        originalDir == currentDir,
+        $"Directory should not change when changeToScriptDirectory is false: {originalDir} != {currentDir}"
+      );
+      
+      AssertTrue(
+        context.ScriptDirectory != null,
+        "ScriptDirectory property should still be set"
+      );
+    }
+    
+    return Task.CompletedTask;
+  }
+  
+  public static Task TestFromRelativePathNavigatesToParent()
+  {
+    string originalDir = Directory.GetCurrentDirectory();
+    
+    // Navigate to parent directory (one level up from script)
+    using (var context = ScriptContext.FromRelativePath(".."))
+    {
+      string currentDir = Directory.GetCurrentDirectory();
+      
+      AssertTrue(
+        currentDir != originalDir,
+        $"Directory should change when using FromRoot: {originalDir} -> {currentDir}"
+      );
+      
+      // Current directory should be the parent of the script directory
+      string scriptDirName = Path.GetFileName(context.ScriptDirectory);
+      string expectedParent = Path.GetDirectoryName(context.ScriptDirectory) ?? "";
+      
+      AssertTrue(
+        currentDir == expectedParent,
+        $"Should be in parent directory: expected {expectedParent}, got {currentDir}"
+      );
+    }
+    
+    // Verify restoration
+    string restoredDir = Directory.GetCurrentDirectory();
+    AssertTrue(
+      originalDir == restoredDir,
+      $"Directory should be restored after FromRelativePath disposal: {originalDir} != {restoredDir}"
+    );
+    
+    return Task.CompletedTask;
+  }
+  
+  public static async Task TestCleanupCallbackExecutes()
+  {
+    bool cleanupExecuted = false;
+    
+    using (var context = ScriptContext.FromEntryPoint(
+      changeToScriptDirectory: false,
+      onExit: () => cleanupExecuted = true))
+    {
+      // Just using the context
+      await Task.Delay(1);
+    }
+    
+    AssertTrue(
+      cleanupExecuted,
+      "Cleanup callback should execute on disposal"
+    );
+  }
+  
+  public static Task TestScriptFilePathIsSet()
+  {
+    using (var context = ScriptContext.FromEntryPoint(changeToScriptDirectory: false))
+    {
+      AssertTrue(
+        context.ScriptFilePath != null,
+        "ScriptFilePath should not be null"
+      );
+      
+      AssertTrue(
+        context.ScriptFilePath!.EndsWith(".cs", StringComparison.Ordinal),
+        $"ScriptFilePath should end with .cs: {context.ScriptFilePath}"
+      );
+    }
+    
+    return Task.CompletedTask;
+  }
+}

--- a/Tests/Manual/TestScriptContextManual.cs
+++ b/Tests/Manual/TestScriptContextManual.cs
@@ -1,0 +1,24 @@
+#!/usr/bin/dotnet --
+#:project ../Source/TimeWarp.Amuru/TimeWarp.Amuru.csproj
+#:property RestoreNoCache=true
+#:property DisableImplicitNuGetFallbackFolder=true
+#:property LangVersion=preview
+#:property EnablePreviewFeatures=true
+
+using TimeWarp.Amuru;
+
+Console.WriteLine("Testing AppContext extensions:");
+Console.WriteLine($"EntryPointFilePath: {AppContext.EntryPointFilePath()}");
+Console.WriteLine($"EntryPointFileDirectoryPath: {AppContext.EntryPointFileDirectoryPath()}");
+
+Console.WriteLine("\nTesting ScriptContext:");
+using (var context = ScriptContext.FromEntryPoint())
+{
+  Console.WriteLine($"ScriptFilePath: {context.ScriptFilePath}");
+  Console.WriteLine($"ScriptDirectory: {context.ScriptDirectory}");
+  Console.WriteLine($"Current Directory: {Directory.GetCurrentDirectory()}");
+}
+
+Console.WriteLine($"Directory restored: {Directory.GetCurrentDirectory()}");
+
+return 0;

--- a/Tests/Manual/TestScriptContextWithExitManual.cs
+++ b/Tests/Manual/TestScriptContextWithExitManual.cs
@@ -1,0 +1,32 @@
+#!/usr/bin/dotnet --
+#:project ../Source/TimeWarp.Amuru/TimeWarp.Amuru.csproj
+#:property LangVersion=preview
+#:property EnablePreviewFeatures=true
+
+using TimeWarp.Amuru;
+
+Console.WriteLine("Testing ScriptContext with Environment.Exit:");
+
+// Create a file to prove cleanup happened
+string markerFile = Path.Combine(Path.GetTempPath(), "scriptcontext-test-marker.txt");
+File.Delete(markerFile); // Clean up from any previous run
+
+using var context = ScriptContext.FromEntryPoint(
+  changeToScriptDirectory: true,
+  onExit: () => 
+  {
+    // This should run even when Environment.Exit is called
+    File.WriteAllText(markerFile, $"Cleanup ran at {DateTime.Now}");
+    Console.WriteLine("✅ Cleanup callback executed!");
+  });
+
+Console.WriteLine($"Script directory: {context.ScriptDirectory}");
+Console.WriteLine($"Working directory: {Directory.GetCurrentDirectory()}");
+Console.WriteLine($"Marker file: {markerFile}");
+Console.WriteLine("Calling Environment.Exit(0)...");
+
+// This should trigger the cleanup
+Environment.Exit(0);
+
+// This line should never be reached
+Console.WriteLine("❌ This should not print!");


### PR DESCRIPTION
## Summary
- Implements ScriptContext and AppContext extensions for .NET 10 file-based apps as requested in #6
- Adds automatic working directory management with disposal pattern
- Uses C# 14 extension syntax for clean API design

## Changes
- **AppContext extensions**: Added `EntryPointFilePath()` and `EntryPointFileDirectoryPath()` extension methods using C# 14 syntax
- **ScriptContext class**: Provides automatic directory management with IDisposable pattern
  - `FromEntryPoint()`: Work in script's directory
  - `FromRelativePath()`: Navigate to relative paths from script
  - Cleanup callbacks that run even with `Environment.Exit()`
- **Documentation**: Added comprehensive how-to guides in Documentation/Developer/HowToGuides/
- **Samples**: Created working examples in Samples/ directory
- **Tests**: Full integration test coverage in Tests/Integration/ScriptSupport/
- **Version**: Bumped to 1.0.0-beta.2

## Test Plan
- [x] All integration tests pass (ScriptContext: 5/5, AppContextExtensions: 3/3)
- [x] Full test suite passes (35 test files)
- [x] Sample scripts execute correctly
- [x] Build scripts updated to use ScriptContext

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)