### PR TITLE
fix: CI/CD tool package generation and bump to beta.7

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,6 +51,9 @@ jobs:
 
           echo "Building TimeWarp.Amuru.Tool..."
           dotnet build Source/TimeWarp.Amuru.Tool/TimeWarp.Amuru.Tool.csproj --configuration Release
+          
+          echo "Packing TimeWarp.Amuru.Tool..."
+          dotnet pack Source/TimeWarp.Amuru.Tool/TimeWarp.Amuru.Tool.csproj --configuration Release --no-build
 
           # Skip tests for now - .NET 10 preview has issues with script execution in CI
           # Tests run fine locally

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,7 +33,7 @@
     <RestorePackagesPath>$(MSBuildThisFileDirectory)LocalNuGetCache</RestorePackagesPath>
 
     <!-- Shared Package Metadata -->
-    <Version>1.0.0-beta.6</Version>
+    <Version>1.0.0-beta.7</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-amuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

Fixed CI/CD issue where TimeWarp.Amuru.Tool package wasn't being created, and bumped version to beta.7.

## Problem
- Beta.6 release partially failed - TimeWarp.Amuru published but TimeWarp.Amuru.Tool didn't
- Tool packages require explicit `dotnet pack` command, not just `dotnet build`

## Solution
- Added `dotnet pack` step for the tool package in CI/CD workflow
- Bumped version to 1.0.0-beta.7 since beta.6 is partially published

## Changes
- ✅ Added pack step: `dotnet pack Source/TimeWarp.Amuru.Tool/TimeWarp.Amuru.Tool.csproj --configuration Release --no-build`
- ✅ Version bumped to 1.0.0-beta.7 in Directory.Build.props

## Testing
After merge and release, both packages should publish successfully to NuGet.

🤖 Generated with [Claude Code](https://claude.ai/code)