### PR TITLE
fix: add missing PackageIcon to tool package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,7 +33,7 @@
     <RestorePackagesPath>$(MSBuildThisFileDirectory)LocalNuGetCache</RestorePackagesPath>
 
     <!-- Shared Package Metadata -->
-    <Version>1.0.0-beta.7</Version>
+    <Version>1.0.0-beta.8</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-amuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>

--- a/Source/TimeWarp.Amuru.Tool/TimeWarp.Amuru.Tool.csproj
+++ b/Source/TimeWarp.Amuru.Tool/TimeWarp.Amuru.Tool.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>Logo.png</PackageIcon>
 
     <!-- .NET Tool Configuration -->
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
## Summary

Fixed missing icon for TimeWarp.Amuru.Tool package on NuGet.org

## Problem
The tool package wasn't displaying the logo icon on NuGet because the `<PackageIcon>` property was missing from the project file.

## Solution
- Added `<PackageIcon>Logo.png</PackageIcon>` to TimeWarp.Amuru.Tool.csproj
- The Logo.png file was already being included in the package, but NuGet didn't know it was the icon

## Changes
- ✅ Added PackageIcon property to tool project
- ✅ Bumped version to 1.0.0-beta.8

## Result
The tool package will now display the icon properly on NuGet.org, matching the library package.

🤖 Generated with [Claude Code](https://claude.ai/code)