### PR TITLE
fix: disable trimming for standalone executables

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -136,23 +136,28 @@ jobs:
           mkdir -p artifacts/osx-x64
           
           # Build each executable for multiple platforms
+          # Note: Trimming is disabled because TimeWarp.Nuru and TimeWarp.Mediator use reflection
+          # for routing and mediator patterns which are not trim-compatible
           for script in multiavatar generate-avatar convert-timestamp generate-color; do
             echo "Building $script..."
-            
+
             # Linux
             dotnet publish exe/$script.cs -c Release -r linux-x64 \
-              --self-contained -p:PublishSingleFile=true -p:PublishTrimmed=true \
-              -p:TrimMode=partial -o artifacts/linux-x64
-            
+              --self-contained -p:PublishSingleFile=true \
+              -p:PublishTrimmed=false \
+              -o artifacts/linux-x64
+
             # Windows
             dotnet publish exe/$script.cs -c Release -r win-x64 \
-              --self-contained -p:PublishSingleFile=true -p:PublishTrimmed=true \
-              -p:TrimMode=partial -o artifacts/win-x64
-            
+              --self-contained -p:PublishSingleFile=true \
+              -p:PublishTrimmed=false \
+              -o artifacts/win-x64
+
             # macOS
             dotnet publish exe/$script.cs -c Release -r osx-x64 \
-              --self-contained -p:PublishSingleFile=true -p:PublishTrimmed=true \
-              -p:TrimMode=partial -o artifacts/osx-x64
+              --self-contained -p:PublishSingleFile=true \
+              -p:PublishTrimmed=false \
+              -o artifacts/osx-x64
           done
           
           # Create archives


### PR DESCRIPTION
## Summary
Fix the release workflow build failures by disabling trimming for standalone executables due to reflection usage in dependencies.

## Problem
The release workflow was failing with IL2104 trim warnings:
- `TimeWarp.Mediator` uses reflection for handler discovery and invocation
- `TimeWarp.Nuru` uses reflection for route parsing and parameter binding

These reflection-based patterns are incompatible with .NET trimming.

## Solution
Explicitly set `PublishTrimmed=false` while keeping `PublishSingleFile=true` for standalone executables.

## Impact
- ✅ Standalone executables will build successfully
- ⚠️ Executables will be larger (~30-50MB instead of ~10-15MB with trimming)
- ℹ️ This is a temporary solution until the dependencies are made trim-compatible

## Related Issues
- TimeWarpEngineering/timewarp-mediator#52 - Replace reflection with source generators
- TimeWarpEngineering/timewarp-nuru#43 - Add AOT/trimming support

## Test Plan
- [ ] Verify release workflow completes successfully
- [ ] Test that standalone executables work correctly
- [ ] Confirm all platforms (linux-x64, win-x64, osx-x64) build properly

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>