### PR TITLE
fix: use Shell.Builder in generate-avatar to resolve CA1031 error

### DIFF
--- a/exe/generate-avatar.cs
+++ b/exe/generate-avatar.cs
@@ -1,117 +1,107 @@
 #!/usr/bin/dotnet --
 
 #:project ../Source/TimeWarp.Multiavatar/TimeWarp.Multiavatar.csproj
+#:project ../Source/TimeWarp.Amuru/TimeWarp.Amuru.csproj
 
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
+using TimeWarp.Amuru;
 using TimeWarp.Multiavatar;
 using static System.Console;
 
 // Main program entry point
-return GenerateAvatar();
+return await GenerateAvatarAsync();
 
-static int GenerateAvatar()
+static async Task<int> GenerateAvatarAsync()
 {
-    string? gitRoot = FindGitRoot();
-    if (gitRoot == null)
-    {
-        WriteLine("Error: Not in a git repository");
-        return 1;
-    }
+  string? gitRoot = FindGitRoot();
+  if (gitRoot == null)
+  {
+    WriteLine("Error: Not in a git repository");
+    return 1;
+  }
 
-    WriteLine($"Git repository root: {gitRoot}");
+  WriteLine($"Git repository root: {gitRoot}");
 
-    string repoName = GetRepositoryName();
-    WriteLine($"Repository name: {repoName}");
+  string repoName = await GetRepositoryNameAsync();
+  WriteLine($"Repository name: {repoName}");
 
-    // Create assets directory if it doesn't exist
-    string assetsDir = Path.Combine(gitRoot, "assets");
-    if (!Directory.Exists(assetsDir))
-    {
-        Directory.CreateDirectory(assetsDir);
-        WriteLine($"Created assets directory: {assetsDir}");
-    }
+  // Create assets directory if it doesn't exist
+  string assetsDir = Path.Combine(gitRoot, "assets");
+  if (!Directory.Exists(assetsDir))
+  {
+    Directory.CreateDirectory(assetsDir);
+    WriteLine($"Created assets directory: {assetsDir}");
+  }
 
-    // Generate avatar
-    string svgCode = MultiavatarGenerator.Generate(repoName);
-    
-    // Save SVG file
-    string svgFilename = Path.Combine(assetsDir, $"{repoName}-avatar.svg");
-    File.WriteAllText(svgFilename, svgCode);
-    WriteLine($"Generated {svgFilename}");
+  // Generate avatar
+  string svgCode = MultiavatarGenerator.Generate(repoName);
 
-    WriteLine($"Successfully generated avatar for '{repoName}'");
+  // Save SVG file
+  string svgFilename = Path.Combine(assetsDir, $"{repoName}-avatar.svg");
+  await File.WriteAllTextAsync(svgFilename, svgCode);
+  WriteLine($"Generated {svgFilename}");
 
-    return 0;
+  WriteLine($"Successfully generated avatar for '{repoName}'");
+
+  return 0;
 }
 
 // Helper functions for git repository detection
 static string? FindGitRoot(string? startPath = null)
 {
-    string currentPath = startPath ?? Directory.GetCurrentDirectory();
-    
-    while (!string.IsNullOrEmpty(currentPath))
+  string currentPath = startPath ?? Directory.GetCurrentDirectory();
+
+  while (!string.IsNullOrEmpty(currentPath))
+  {
+    string gitPath = Path.Combine(currentPath, ".git");
+
+    // Check if .git exists (either as directory or file for worktrees)
+    if (Directory.Exists(gitPath) || File.Exists(gitPath))
     {
-        string gitPath = Path.Combine(currentPath, ".git");
-        
-        // Check if .git exists (either as directory or file for worktrees)
-        if (Directory.Exists(gitPath) || File.Exists(gitPath))
-        {
-            return currentPath;
-        }
-        
-        DirectoryInfo? parent = Directory.GetParent(currentPath);
-        if (parent == null)
-        {
-            break;
-        }
-        
-        currentPath = parent.FullName;
+      return currentPath;
     }
-    
-    return null;
+
+    DirectoryInfo? parent = Directory.GetParent(currentPath);
+    if (parent == null)
+    {
+      break;
+    }
+
+    currentPath = parent.FullName;
+  }
+
+  return null;
 }
 
-static string GetRepositoryName()
+static async Task<string> GetRepositoryNameAsync()
 {
-    // Try to get from git remote first
-    var processInfo = new System.Diagnostics.ProcessStartInfo
+  // Try to get from git remote using Shell.Builder
+  CommandOutput result =
+    await Shell.Builder("git")
+    .WithArguments("remote", "get-url", "origin")
+    .WithNoValidation() // Don't throw on failure
+    .CaptureAsync();
+
+  if (result.Success && !string.IsNullOrWhiteSpace(result.Stdout))
+  {
+    string output = result.Stdout.Trim();
+
+    // Extract repo name from URL
+    if (output.Contains("github.com", StringComparison.OrdinalIgnoreCase))
     {
-        FileName = "git",
-        Arguments = "remote get-url origin",
-        RedirectStandardOutput = true,
-        UseShellExecute = false,
-        CreateNoWindow = true
-    };
-    
-    try
-    {
-        using var process = System.Diagnostics.Process.Start(processInfo);
-        if (process != null)
-        {
-            string output = process.StandardOutput.ReadToEnd().Trim();
-            process.WaitForExit();
-            
-            if (process.ExitCode == 0 && !string.IsNullOrWhiteSpace(output))
-            {
-                // Extract repo name from URL
-                if (output.Contains("github.com", StringComparison.OrdinalIgnoreCase))
-                {
-                    string repoName = output.Split('/').Last();
-                    if (repoName.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
-                    {
-                        repoName = repoName.Substring(0, repoName.Length - 4);
-                    }
-                    
-                    return repoName;
-                }
-            }
-        }
+      string repoName = output.Split('/').Last();
+      if (repoName.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+      {
+        repoName = repoName[..^4]; // Remove ".git" suffix
+      }
+
+      return repoName;
     }
-    catch { }
-    
-    // Fallback to directory name
-    string? gitRoot = FindGitRoot();
-    return gitRoot != null ? new DirectoryInfo(gitRoot).Name : "avatar";
+  }
+
+  // Fallback to directory name
+  string? gitRoot = FindGitRoot();
+  return gitRoot != null ? new DirectoryInfo(gitRoot).Name : "avatar";
 }


### PR DESCRIPTION
## Summary
Fix release build failure by replacing Process.Start with Shell.Builder in generate-avatar.cs

## Problem
The release workflow was failing with:
```
error CA1031: Modify '<Main>$' to catch a more specific allowed exception type, or rethrow the exception
```

The script had a catch-all exception handler that was violating code analysis rules.

## Solution
- Replace raw `Process.Start` with `Shell.Builder` from TimeWarp.Amuru
- Use `WithNoValidation()` to handle git failures gracefully
- Remove the problematic catch-all exception handler
- Make the code properly async throughout

## Benefits
- ✅ Fixes the CA1031 error blocking releases
- ✅ Eating our own dog food by using Amuru's API
- ✅ Cleaner, more maintainable code
- ✅ Proper async/await pattern
- ✅ No more exception swallowing

## Test Plan
- [ ] Verify release workflow completes successfully
- [ ] Test generate-avatar script works correctly
- [ ] Confirm it handles missing git gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>