### PR TITLE
fix: suppress IL3053 AOT analysis warnings

### DIFF
--- a/exe/convert-timestamp.cs
+++ b/exe/convert-timestamp.cs
@@ -1,7 +1,7 @@
 #!/usr/bin/dotnet --
 #:package TimeWarp.Nuru
 #:property TrimMode=partial
-#:property NoWarn=IL2104
+#:property NoWarn=IL2104;IL3053
 
 using TimeWarp.Nuru;
 using static System.Console;

--- a/exe/generate-avatar.cs
+++ b/exe/generate-avatar.cs
@@ -3,7 +3,7 @@
 #:project ../Source/TimeWarp.Multiavatar/TimeWarp.Multiavatar.csproj
 #:project ../Source/TimeWarp.Amuru/TimeWarp.Amuru.csproj
 #:property TrimMode=partial
-#:property NoWarn=IL2104
+#:property NoWarn=IL2104;IL3053
 
 using System.Security.Cryptography;
 using System.Text;

--- a/exe/generate-color.cs
+++ b/exe/generate-color.cs
@@ -2,7 +2,7 @@
 
 #:package TimeWarp.Nuru
 #:property TrimMode=partial
-#:property NoWarn=IL2104
+#:property NoWarn=IL2104;IL3053
 
 using System.Security.Cryptography;
 using System.Text;

--- a/exe/multiavatar.cs
+++ b/exe/multiavatar.cs
@@ -2,7 +2,7 @@
 
 #:project ../Source/TimeWarp.Multiavatar/TimeWarp.Multiavatar.csproj
 #:property TrimMode=partial
-#:property NoWarn=IL2104
+#:property NoWarn=IL2104;IL3053
 
 using TimeWarp.Multiavatar;
 using TimeWarp.Nuru;

--- a/exe/post.cs
+++ b/exe/post.cs
@@ -3,7 +3,7 @@
 #:package TimeWarp.Nuru
 #:package Blockcore.Nostr.Client
 #:property TrimMode=partial
-#:property NoWarn=IL2104
+#:property NoWarn=IL2104;IL3053
 
 using TimeWarp.Nuru;
 using Nostr.Client.Client;


### PR DESCRIPTION
## Summary
Add IL3053 to NoWarn properties to suppress AOT analysis warnings from TimeWarp.Nuru and TimeWarp.Mediator.

## Problem
The release workflow was still failing with:
```
error IL3053: Assembly 'TimeWarp.Nuru' produced AOT analysis warnings.
error IL3053: Assembly 'TimeWarp.Mediator' produced AOT analysis warnings.
```

## Solution
Add `IL3053` to the NoWarn property alongside `IL2104` in all scripts that use TimeWarp.Nuru.

This matches what Nuru itself does in its project file:
```xml
<NoWarn>$(NoWarn);CA1812;CA1014;IL2026;IL2067;IL2070;IL2075;IL3050;IL2104;IL3053</NoWarn>
```

## Files Updated
- multiavatar.cs
- generate-avatar.cs
- convert-timestamp.cs
- generate-color.cs
- post.cs

All now have: `#:property NoWarn=IL2104;IL3053`

## Test Plan
- [ ] Verify release workflow completes successfully
- [ ] Test that standalone executables work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>