### PR TITLE
Remove EnablePreviewFeatures to fix CA2252 warnings

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,7 @@ on:
       - 'Scripts/**'
       - '.github/workflows/**'
       - 'exe/**'
+      - 'Directory.Build.props'
   pull_request:
     branches:
       - master
@@ -19,8 +20,10 @@ on:
       - 'Scripts/**'
       - '.github/workflows/**'
       - 'exe/**'
+      - 'Directory.Build.props'
   release:
     types: [published] # Triggered when a release is published via GitHub Releases UI or gh CLI
+  workflow_dispatch: # Allow manual triggering
 
 # Required permissions for GitHub attestations and releases
 permissions:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,6 @@
     <!-- Common .NET SDK Properties -->
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>preview</LangVersion>
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -33,7 +32,7 @@
     <RestorePackagesPath>$(MSBuildThisFileDirectory)LocalNuGetCache</RestorePackagesPath>
 
     <!-- Shared Package Metadata -->
-    <Version>1.0.0-beta.12</Version>
+    <Version>1.0.0-beta.13</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-amuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="ModelContextProtocol.Core" Version="0.3.0-preview.4" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="StreamJsonRpc" Version="2.23.32-alpha" />
-    <PackageVersion Include="TimeWarp.Multiavatar" Version="1.0.0-beta.10" />
+    <PackageVersion Include="TimeWarp.Multiavatar" Version="1.0.0-beta.12" />
     <PackageVersion Include="TimeWarp.Nuru" Version="2.1.0-beta.9" />
   </ItemGroup>
 </Project>

--- a/Kanban/ToDo/045_Implement-Native-Tee-Command.md
+++ b/Kanban/ToDo/045_Implement-Native-Tee-Command.md
@@ -1,0 +1,111 @@
+# 045 Implement Native Tee Command
+
+## Description
+
+Investigate and implement the `tee` command as a Native command in TimeWarp.Amuru. The `tee` command reads from stdin and writes to both stdout and one or more files simultaneously, enabling output capture while maintaining console visibility.
+
+## Use Case
+
+```bash
+cd Scripts && ./Build.cs 2>&1 | tee /tmp/build-output.txt
+```
+
+This allows build output to be both displayed in the console and saved to a file for later analysis.
+
+## Requirements
+
+- Implement tee command with both Commands and Direct APIs
+- Support writing to multiple files simultaneously
+- Support append mode (-a flag equivalent)
+- Follow PowerShell verb-noun naming convention with bash alias
+- Maintain consistency with existing FileSystem implementation
+- Consider integration with Tests/Integration/Native/FileSystem/
+
+## Checklist
+
+### Design
+- [ ] Determine appropriate PowerShell-style name (WriteObject? TeeObject?)
+- [ ] Design API signature for Commands and Direct
+- [ ] Decide on append vs overwrite behavior
+- [ ] Consider multi-file output support
+- [ ] Plan integration with existing pipeline operations
+
+### Implementation
+- [ ] Create Native/FileSystem/Commands/Commands.Tee.cs
+  - [ ] Implement Tee(string input, string filePath, bool append = false)
+  - [ ] Support multiple file paths
+  - [ ] Handle errors with proper stderr/exit codes
+  - [ ] No exceptions thrown - shell semantics
+
+- [ ] Create Native/FileSystem/Direct/Direct.Tee.cs
+  - [ ] Implement TeeAsync returning IAsyncEnumerable<string>
+  - [ ] Stream processing for large inputs
+  - [ ] LINQ-composable operations
+  - [ ] Proper exception handling for file operations
+
+### Alias System Updates
+- [ ] Update Native/Aliases/Bash.cs
+  - [ ] Tee(input, filePath, append) => FileSystem.Commands.Tee()
+
+### Testing
+- [ ] Create Tests/Integration/Native/FileSystem/TeeTests.cs
+- [ ] Test basic tee functionality (stdout + file)
+- [ ] Test append mode
+- [ ] Test multiple file outputs
+- [ ] Test with large input streams
+- [ ] Test error handling (permission denied, disk full, etc.)
+- [ ] Test both Commands and Direct APIs
+- [ ] Test bash alias works correctly
+
+## Implementation Notes
+
+### Example Usage
+
+```csharp
+// PowerShell-style
+var result = Tee(buildOutput, "/tmp/build-output.txt");
+
+// With append mode
+var result = Tee(logOutput, "/var/log/app.log", append: true);
+
+// Multiple files
+var result = Tee(output, new[] { "/tmp/output1.txt", "/tmp/output2.txt" });
+
+// Bash-style alias
+var result = Tee(output, "/tmp/output.txt");
+
+// Direct API for streaming
+await foreach (var line in Direct.TeeAsync(inputStream, "/tmp/output.txt"))
+{
+    // Line is written to file and yielded to stdout
+    Console.WriteLine(line);
+}
+```
+
+### Design Considerations
+
+1. **Streaming**: Use IAsyncEnumerable for memory efficiency with large inputs
+2. **Atomicity**: Consider buffering strategy for file writes
+3. **Error Handling**: Decide how to handle partial failures (e.g., file write fails mid-stream)
+4. **Encoding**: Handle UTF-8 by default, with options for other encodings
+5. **Performance**: Minimize overhead compared to direct file writes
+6. **Cross-platform**: Ensure behavior is consistent across Windows/Linux/macOS
+
+### Open Questions
+
+- Should tee integrate with existing pipeline operations?
+- Should it support binary data or just text?
+- How should it handle file locking scenarios?
+- Should it support compression on-the-fly?
+
+## Dependencies
+
+- Builds on existing Native/FileSystem implementation
+- Follows CommandOutput and dual API pattern established
+- May relate to Task 023 (Native Text Commands) for pipeline integration
+
+## References
+
+- Unix `tee` command behavior
+- PowerShell `Tee-Object` cmdlet
+- .NET file I/O and streaming APIs


### PR DESCRIPTION
## Summary
- Removed `EnablePreviewFeatures` from Directory.Build.props to eliminate CA2252 warnings for consumers
- Bumped version to 1.0.0-beta.13
- Includes test refactoring and FileSystem improvements from prior commits

## Changes
The main fix removes `EnablePreviewFeatures=true` which was causing CA2252 analyzer warnings when other projects consume the Amuru library. Testing confirmed the codebase builds successfully without this setting - `LangVersion=preview` is sufficient for preview C# language features without marking the entire assembly as requiring preview features.

## Test plan
- [x] Build succeeds without EnablePreviewFeatures
- [x] All existing tests pass
- [x] Version bumped for new release

🤖 Generated with [Claude Code](https://claude.com/claude-code)