### PR TITLE
chore: bump version to 1.0.0-beta.24

### DIFF
--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -5,7 +5,7 @@
   <!-- Default package metadata (can be overridden in individual projects) -->
   <PropertyGroup Label="Package Metadata">
     <IsPackable>true</IsPackable>
-    <Version>1.0.0-beta.23</Version>
+    <Version>1.0.0-beta.24</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-amuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

- Bumps version from 1.0.0-beta.23 to 1.0.0-beta.24 in `source/Directory.Build.props`
- Prepares for next release after beta.23 was published