### PR TITLE
fix: release pipeline fails silently when version already exists

### DIFF
--- a/tools/dev-cli/endpoints/workflow-command.cs
+++ b/tools/dev-cli/endpoints/workflow-command.cs
@@ -152,14 +152,39 @@ internal sealed class WorkflowCommand : ICommand<Unit>
       Terminal.WriteLine("===============================================================================");
       Terminal.WriteLine("  Step 3/4: Check Version");
       Terminal.WriteLine("===============================================================================");
+      NuGetPackageService nuGetPackageService = new();
+      RepoConfigService repoConfigService = new();
+      RepoCheckVersionService repoCheckVersionService = new(nuGetPackageService, repoConfigService);
+
+      CheckVersionResult checkResult = await repoCheckVersionService.CheckAsync(cancellationToken: CancellationToken.None);
+
       CheckVersionCommand.Handler checkVersionHandler = new(Terminal);
       await checkVersionHandler.Handle(new CheckVersionCommand(), CancellationToken.None);
+
+      if (!checkResult.IsNewVersion)
+      {
+        Terminal.WriteErrorLine("");
+        Terminal.WriteErrorLine("===============================================================================");
+        Terminal.WriteErrorLine("  Pipeline FAILED - Version is not new, cannot release");
+        Terminal.WriteErrorLine("===============================================================================");
+        Environment.ExitCode = 1;
+        return;
+      }
 
       Terminal.WriteLine("");
       Terminal.WriteLine("===============================================================================");
       Terminal.WriteLine("  Step 4/4: Push to NuGet");
       Terminal.WriteLine("===============================================================================");
       await PushPackageAsync(repoRoot, apiKey);
+
+      if (Environment.ExitCode != 0)
+      {
+        Terminal.WriteErrorLine("");
+        Terminal.WriteErrorLine("===============================================================================");
+        Terminal.WriteErrorLine("  Pipeline FAILED - Package push failed");
+        Terminal.WriteErrorLine("===============================================================================");
+        return;
+      }
 
       Terminal.WriteLine("");
       Terminal.WriteLine("===============================================================================");
@@ -189,7 +214,7 @@ internal sealed class WorkflowCommand : ICommand<Unit>
 
       Terminal.WriteLine($"Pushing TimeWarp.Amuru.{version}.nupkg...");
 
-      List<string> args = ["nuget", "push", nupkgPath, "--source", "https://api.nuget.org/v3/index.json", "--skip-duplicate"];
+      List<string> args = ["nuget", "push", nupkgPath, "--source", "https://api.nuget.org/v3/index.json"];
 
       if (!string.IsNullOrEmpty(apiKey))
       {
@@ -202,7 +227,14 @@ internal sealed class WorkflowCommand : ICommand<Unit>
         .WithNoValidation()
         .RunAsync();
 
-      Terminal.WriteLine("\nPackage pushed successfully!");
+      if (exitCode != 0)
+      {
+        Terminal.WriteErrorLine($"\n❌ NuGet push failed with exit code {exitCode}");
+        Environment.ExitCode = 1;
+        return;
+      }
+
+      Terminal.WriteLine("\n✅ Package pushed successfully!");
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Gates release on `IsNewVersion`** — pipeline now aborts before NuGet push if check-version determines the version already exists
- **Removes `--skip-duplicate`** from `dotnet nuget push` — duplicate packages now correctly fail instead of being silently swallowed
- **Checks push exit code** — pipeline fails with clear error message instead of unconditionally printing "Package pushed successfully!"

## Root Cause

The v1.0.0-beta.24 release ran CI against master which still had beta.23 in source. The pipeline:
1. Built beta.23 package
2. check-version said "new" (comparing beta.23 against tag v1.0.0-beta.24)
3. Pushed beta.23 which already existed on NuGet → got 409 Conflict
4. `--skip-duplicate` treated conflict as success
5. Pipeline printed "SUCCEEDED" despite publishing nothing