### PR TITLE
fix: add --no-symbols to nuget push to avoid empty snupkg rejection

### DIFF
--- a/tools/dev-cli/endpoints/workflow-command.cs
+++ b/tools/dev-cli/endpoints/workflow-command.cs
@@ -207,7 +207,7 @@ internal sealed class WorkflowCommand : ICommand<Unit>
 
       Terminal.WriteLine($"Pushing TimeWarp.Amuru.{version}.nupkg...");
 
-      List<string> args = ["nuget", "push", nupkgPath, "--source", "https://api.nuget.org/v3/index.json"];
+      List<string> args = ["nuget", "push", nupkgPath, "--source", "https://api.nuget.org/v3/index.json", "--no-symbols"];
 
       if (!string.IsNullOrEmpty(apiKey))
       {


### PR DESCRIPTION
## Summary

- Adds `--no-symbols` to `dotnet nuget push` command
- Project uses `<DebugType>embedded</DebugType>` so PDBs are in the main `.nupkg`, making the `.snupkg` empty
- NuGet rejects empty symbol packages with `400: The package does not contain any symbol (.pdb) files`