### PR TITLE
chore: bump version to 1.0.0-beta.27

### DIFF
--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -5,7 +5,7 @@
   <!-- Default package metadata (can be overridden in individual projects) -->
   <PropertyGroup Label="Package Metadata">
     <IsPackable>true</IsPackable>
-    <Version>1.0.0-beta.26</Version>
+    <Version>1.0.0-beta.27</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-amuru</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>


### PR DESCRIPTION
Bump version for release with actual implementation.